### PR TITLE
Small bug fix of missing argument for args["ignore_quality_change"]

### DIFF
--- a/livestream_saver.py
+++ b/livestream_saver.py
@@ -890,7 +890,7 @@ def main():
         args["hooks"] = get_hooks_for_section(sub_cmd, config, "_command")
         args["cookie"] = config.get(sub_cmd, "cookie", vars=args, fallback=None)
         args["ignore_quality_change"] = config.get(
-            "ignore_quality_change", vars=args, fallback=False)
+            sub_cmd, "ignore_quality_change", vars=args, fallback=False)
 
         NOTIFIER.webhooks = get_hooks_for_section(sub_cmd, config, "_webhook")
         NOTIFIER.setup(config, args)


### PR DESCRIPTION
Fixed "TypeError: get() missing 1 required positional argument: 'option'" that occured when running the application.